### PR TITLE
Specify the use of JRuby in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
+ruby "1.9.3", :engine => "jruby", :engine_version => "1.7.22"
 gemspec


### PR DESCRIPTION
I've experienced and seen some confusion where people don't realize that they need to use JRuby for Logstash plugin development. Specifying it in the Gemfile is one way to prevent that confusion.

Thoughts?
